### PR TITLE
Don't compare default graph values

### DIFF
--- a/dist/rdf-data-model.js
+++ b/dist/rdf-data-model.js
@@ -82,7 +82,7 @@ function DefaultGraph () {
 }
 
 DefaultGraph.prototype.equals = function (other) {
-  return other.termType === this.termType && other.value === this.value
+  return other.termType === this.termType
 }
 
 DefaultGraph.prototype.termType = 'DefaultGraph'

--- a/lib/default-graph.js
+++ b/lib/default-graph.js
@@ -5,7 +5,7 @@ function DefaultGraph () {
 }
 
 DefaultGraph.prototype.equals = function (other) {
-  return other.termType === this.termType && other.value === this.value
+  return other.termType === this.termType
 }
 
 DefaultGraph.prototype.termType = 'DefaultGraph'

--- a/test/default-graph.js
+++ b/test/default-graph.js
@@ -42,13 +42,6 @@ function runTests (DataFactory) {
 
         assert.equal(term.equals(mock), false)
       })
-
-      it('should return false if value is not equal', function () {
-        var term = DataFactory.defaultGraph()
-        var mock = {termType: 'DefaultGraph', value: '1'}
-
-        assert.equal(term.equals(mock), false)
-      })
     })
   })
 }


### PR DESCRIPTION
According to the [RDFJS spec](https://github.com/rdfjs/representation-task-force/blob/master/interface-spec.md#defaultgraph-extends-term),
default graphs are equal _if and only if other has termType "DefaultGraph"._.
This commit makes it so that the value is ignored.