### PR TITLE
Return null for equals with falsy values

### DIFF
--- a/lib/blank-node.js
+++ b/lib/blank-node.js
@@ -5,7 +5,7 @@ function BlankNode (id) {
 }
 
 BlankNode.prototype.equals = function (other) {
-  return other.termType === this.termType && other.value === this.value
+  return !!other && other.termType === this.termType && other.value === this.value
 }
 
 BlankNode.prototype.termType = 'BlankNode'

--- a/lib/default-graph.js
+++ b/lib/default-graph.js
@@ -5,7 +5,7 @@ function DefaultGraph () {
 }
 
 DefaultGraph.prototype.equals = function (other) {
-  return other.termType === this.termType && other.value === this.value
+  return !!other && other.termType === this.termType && other.value === this.value
 }
 
 DefaultGraph.prototype.termType = 'DefaultGraph'

--- a/lib/literal.js
+++ b/lib/literal.js
@@ -14,7 +14,7 @@ function Literal (value, language, datatype) {
 }
 
 Literal.prototype.equals = function (other) {
-  return other.termType === this.termType && other.value === this.value &&
+  return !!other && other.termType === this.termType && other.value === this.value &&
     other.language === this.language && other.datatype.equals(this.datatype)
 }
 

--- a/lib/named-node.js
+++ b/lib/named-node.js
@@ -5,7 +5,7 @@ function NamedNode (iri) {
 }
 
 NamedNode.prototype.equals = function (other) {
-  return other.termType === this.termType && other.value === this.value
+  return !!other && other.termType === this.termType && other.value === this.value
 }
 
 NamedNode.prototype.termType = 'NamedNode'

--- a/lib/quad.js
+++ b/lib/quad.js
@@ -13,7 +13,7 @@ function Quad (subject, predicate, object, graph) {
 }
 
 Quad.prototype.equals = function (other) {
-  return other.subject.equals(this.subject) && other.predicate.equals(this.predicate) &&
+  return !!other && other.subject.equals(this.subject) && other.predicate.equals(this.predicate) &&
     other.object.equals(this.object) && other.graph.equals(this.graph)
 }
 

--- a/lib/variable.js
+++ b/lib/variable.js
@@ -5,7 +5,7 @@ function Variable (name) {
 }
 
 Variable.prototype.equals = function (other) {
-  return other.termType === this.termType && other.value === this.value
+  return !!other && other.termType === this.termType && other.value === this.value
 }
 
 Variable.prototype.termType = 'Variable'

--- a/test/blank-node.js
+++ b/test/blank-node.js
@@ -60,6 +60,13 @@ function runTests (DataFactory) {
 
         assert.equal(term.equals(mock), false)
       })
+
+      it('should return false if value is falsy', function () {
+        var id = 'b1'
+        var term = DataFactory.blankNode(id)
+
+        assert.equal(term.equals(null), false)
+      })
     })
   })
 }

--- a/test/default-graph.js
+++ b/test/default-graph.js
@@ -49,6 +49,12 @@ function runTests (DataFactory) {
 
         assert.equal(term.equals(mock), false)
       })
+
+      it('should return false if value is falsy', function () {
+        var term = DataFactory.defaultGraph()
+
+        assert.equal(term.equals(null), false)
+      })
     })
   })
 }

--- a/test/literal.js
+++ b/test/literal.js
@@ -149,6 +149,14 @@ function runTests (DataFactory) {
 
         assert.equal(term.equals(mock), false)
       })
+
+      it('should return false if value is falsy', function () {
+        var string = 'example'
+        var language = 'en'
+        var term = DataFactory.literal(string, language)
+
+        assert.equal(term.equals(null), false)
+      })
     })
   })
 }

--- a/test/named-node.js
+++ b/test/named-node.js
@@ -55,6 +55,13 @@ function runTests (DataFactory) {
 
         assert.equal(term.equals(mock), false)
       })
+
+      it('should return false if value is falsy', function () {
+        var iri = 'http://example.org'
+        var term = DataFactory.namedNode(iri)
+
+        assert.equal(term.equals(null), false)
+      })
     })
   })
 }

--- a/test/quad.js
+++ b/test/quad.js
@@ -92,6 +92,16 @@ function runTests (DataFactory) {
 
         assert.equal(quad1.equals(quad2), false)
       })
+
+      it('should return false if value is falsy', function () {
+        var subject = DataFactory.namedNode('http://example.org/subject')
+        var predicate = DataFactory.namedNode('http://example.org/predicate')
+        var object = DataFactory.namedNode('http://example.org/object')
+        var graph = DataFactory.namedNode('http://example.org/graph')
+        var quad = DataFactory.quad(subject, predicate, object, graph)
+
+        assert.equal(quad.equals(null), false)
+      })
     })
   })
 }

--- a/test/triple.js
+++ b/test/triple.js
@@ -86,6 +86,15 @@ function runTests (DataFactory) {
 
         assert.equal(triple.equals(quad), false)
       })
+
+      it('should return false if value is falsy', function () {
+        var subject = DataFactory.namedNode('http://example.org/subject')
+        var predicate = DataFactory.namedNode('http://example.org/predicate')
+        var object = DataFactory.namedNode('http://example.org/object')
+        var triple = DataFactory.triple(subject, predicate, object)
+
+        assert.equal(triple.equals(null), false)
+      })
     })
   })
 }

--- a/test/variable.js
+++ b/test/variable.js
@@ -59,6 +59,13 @@ function runTests (DataFactory) {
 
         assert.equal(term.equals(mock), false)
       })
+
+      it('should return false if value is falsy', function () {
+        var name = 'v'
+        var term = DataFactory.variable(name)
+
+        assert.equal(term.equals(null), false)
+      })
     })
   })
 }


### PR DESCRIPTION
Currently, `.equals` fails with falsy values. This PR fixes that.